### PR TITLE
refactor: Apply health check recommendations and simplify gallery

### DIFF
--- a/src/components/gallery/GalleryContext.tsx
+++ b/src/components/gallery/GalleryContext.tsx
@@ -7,12 +7,12 @@ import { filterImagesByCategory } from '../../utils/galleryUtils';
 interface GalleryContextType {
   images: GalleryImage[];
   filteredImages: GalleryImage[];
-  activeCategory: GalleryCategory;
+  // activeCategory: GalleryCategory; // Removed
   selectedImage: string | null;
   currentIndex: number;
   imagesLoaded: number;
   loading: boolean;
-  setActiveCategory: (category: GalleryCategory) => void;
+  // setActiveCategory: (category: GalleryCategory) => void; // Removed
   openModal: (img: string, index: number) => void;
   closeModal: () => void;
   nextImage: () => void;
@@ -40,21 +40,18 @@ export const GalleryProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const initialImageCount = 10; // Define initial image count
 
   const [images] = useState<GalleryImage[]>(galleryImagesList);
-  const [activeCategory, setActiveCategory] = useState<GalleryCategory>('all');
-  const [filteredImages, setFilteredImages] = useState<GalleryImage[]>(galleryImagesList);
+  // const [activeCategory, setActiveCategory] = useState<GalleryCategory>('all'); // Removed
+  const [filteredImages, setFilteredImages] = useState<GalleryImage[]>(images); // Initialize with full list from images state
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [imagesLoaded, setImagesLoaded] = useState(0);
   const [loading, setLoading] = useState(true); // Initialize to true
   const [showAllImages, setShowAllImages] = useState(false); // New state for showing all images
 
-  // Set filtered images when category changes
-  useEffect(() => {
-    const filtered = filterImagesByCategory(images, activeCategory);
-    setFilteredImages(filtered);
-    setShowAllImages(false); // Reset when category changes
-    // No need to set imagesLoaded or loading here, it will be handled by the imagesToDisplay useEffect
-  }, [activeCategory, images]);
+  // Removed useEffect that depended on activeCategory
+  // filteredImages is now initialized with `images` and does not change due to category.
+  // If setShowAllImages(false) was critical for some other reset logic,
+  // it might need to be re-evaluated. For now, it's removed as it was tied to category changes.
 
   // Function to set showAllImages to true
   const displayAllImages = () => {
@@ -133,12 +130,12 @@ export const GalleryProvider: React.FC<{ children: React.ReactNode }> = ({ child
       value={{
         images, 
         filteredImages, 
-        activeCategory,
+        // activeCategory, // Removed
         selectedImage,
         currentIndex,
         imagesLoaded, 
         loading, 
-        setActiveCategory,
+        // setActiveCategory, // Removed
         openModal,
         closeModal,
         nextImage,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,8 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+// interface CommandDialogProps extends DialogProps {} // Original
+type CommandDialogProps = DialogProps; // Changed to type alias to satisfy no-empty-object-type
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+// export interface TextareaProps
+//  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {} // Original
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>; // Changed to type alias
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/utils/galleryUtils.ts
+++ b/src/utils/galleryUtils.ts
@@ -29,11 +29,3 @@ export const getFeaturedImages = (images: GalleryImage[], limit = 5): GalleryIma
     .filter(img => img.featured)
     .slice(0, limit);
 };
-
-// Count images by category
-export const countImagesByCategory = (
-  images: GalleryImage[], 
-  category: GalleryCategory
-): number => {
-  return filterImagesByCategory(images, category).length;
-};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate"; // Added import
 
 export default {
 	darkMode: ["class"],
@@ -126,5 +127,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [tailwindcssAnimate], // Used imported variable
 } satisfies Config;


### PR DESCRIPTION
This commit addresses several recommendations from a comprehensive frontend health check and refactors the gallery logic.

Fixes:
- Resolved 3 ESLint errors:
    - 2x @typescript-eslint/no-empty-object-type in src/components/ui/command.tsx and src/components/ui/textarea.tsx (changed {} to type aliases).
    - 1x @typescript-eslint/no-require-imports in tailwind.config.ts (changed require to import).

Refactoring:
- Removed the unused `countImagesByCategory` function from src/utils/galleryUtils.ts.
- Simplified `src/components/gallery/GalleryContext.tsx`:
    - Removed the `activeCategory` state and `setActiveCategory` function as category filtering is no longer used.
    - `filteredImages` state is now initialized directly with the complete list of images, removing the useEffect previously used for category-based filtering.
    - Context provider value updated to exclude the removed state and function.

These changes improve code quality, remove dead code, and simplify the gallery's data management following the removal of category features.